### PR TITLE
Align repository with DPC conventions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,33 @@
+# Copilot Instructions
+
+This repository follows the DPC (Dans Plugins Community) conventions defined at
+https://github.com/Dans-Plugins/dpc-conventions. Read those conventions before
+making any changes.
+
+## Technology Stack
+
+- Language: Java
+- Build tool: Maven
+- Target platform: Spigot / Paper (Minecraft plugin)
+- API version: 1.13+
+
+## Project Structure
+
+- `src/main/java/dansplugins/minifactions/` – Plugin source code
+- `src/main/java/dansplugins/minifactions/commands/` – Command handlers
+- `src/main/java/dansplugins/minifactions/eventhandlers/` – Event listeners
+- `src/main/java/dansplugins/minifactions/objects/` – Domain objects (Faction, FactionPlayer, etc.)
+- `src/main/java/dansplugins/minifactions/services/` – Services (config, etc.)
+- `src/main/resources/` – `plugin.yml` and resource files
+
+## Coding Conventions
+
+- Follow existing package structure when adding new classes.
+- Commands extend `AbstractMFCommand`.
+- Config options are managed through `LocalConfigService`.
+
+## Contribution Workflow
+
+- Branch from `main` for all changes.
+- Open a pull request against `main`.
+- Reference the related GitHub issue in every pull request description.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+name: Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Build with Maven
+        run: mvn clean package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release
+
+on:
+  release:
+    types: [ created ]
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-attach:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Build with Maven
+        run: mvn clean package
+
+      - name: Upload JAR to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            target/*.jar
+            !target/original-*.jar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+
+## [0.1-ALPHA]
+
+### Added
+- Faction creation, disbanding, and management commands
+- Player invitation and kick system
+- Faction territory claiming via chunk system
+- Power system: players gain and lose power, which limits territory size
+- Config options for power costs, death penalty, and chunk requirements
+- `/mf config` command for in-game configuration management

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -5,18 +5,18 @@ All commands use `/mf` or `/minifactions` or `/factions` or `/f` as the base.
 | Command | Description | Permission |
 |---------|-------------|------------|
 | `/mf help` | View a list of commands. | `mf.help` |
-| `/mf list` | View a list of all factions. | `mf.help` |
-| `/mf info` | View information about your faction. | `mf.help` |
-| `/mf create <name>` | Create a new faction. | `mf.help` |
-| `/mf join <faction>` | Join a faction you have been invited to. | `mf.help` |
-| `/mf leave` | Leave your current faction. | `mf.help` |
-| `/mf invite <player>` | Invite a player to your faction. | `mf.help` |
-| `/mf kick <player>` | Kick a player from your faction. | `mf.help` |
-| `/mf disband` | Disband your faction. | `mf.help` |
-| `/mf transfer <player>` | Transfer faction ownership to another player. | `mf.help` |
-| `/mf power` | Check your current power level. | `mf.help` |
-| `/mf claim` | Claim the chunk you are standing in for your faction. | `mf.help` |
-| `/mf unclaim` | Unclaim the chunk you are standing in. | `mf.help` |
-| `/mf checkclaim` | Check which faction owns the chunk you are standing in. | `mf.help` |
-| `/mf config <view\|set> [option] [value]` | View or set config options. | `mf.help` |
-| `/mf force <subcommand>` | Force server events to occur (admin). | `mf.help` |
+| `/mf list` | View a list of all factions. | `mf.list` |
+| `/mf info` | View information about your faction. | `mf.info` |
+| `/mf create <name>` | Create a new faction. | `mf.create` |
+| `/mf join <faction>` | Join a faction you have been invited to. | `mf.join` |
+| `/mf leave` | Leave your current faction. | `mf.leave` |
+| `/mf invite <player>` | Invite a player to your faction. | `mf.invite` |
+| `/mf kick <player>` | Kick a player from your faction. | `mf.kick` |
+| `/mf disband` | Disband your faction. | `mf.disband` |
+| `/mf transfer <player>` | Transfer faction ownership to another player. | `mf.transfer` |
+| `/mf power` | Check your current power level. | `mf.power` |
+| `/mf claim` | Claim the chunk you are standing in for your faction. | `mf.claim` |
+| `/mf unclaim` | Unclaim the chunk you are standing in. | `mf.unclaim` |
+| `/mf checkclaim` (alias: `/mf cc`) | Check which faction owns the chunk you are standing in. | `mf.checkclaim` |
+| `/mf config <show\|set> [option] [value]` | Show or set config options. | `mf.config` |
+| `/mf force <subcommand>` | Force server events to occur (admin). | `mf.force` |

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -1,0 +1,22 @@
+# MiniFactions Commands
+
+All commands use `/mf` or `/minifactions` or `/factions` or `/f` as the base.
+
+| Command | Description | Permission |
+|---------|-------------|------------|
+| `/mf help` | View a list of commands. | `mf.help` |
+| `/mf list` | View a list of all factions. | `mf.help` |
+| `/mf info` | View information about your faction. | `mf.help` |
+| `/mf create <name>` | Create a new faction. | `mf.help` |
+| `/mf join <faction>` | Join a faction you have been invited to. | `mf.help` |
+| `/mf leave` | Leave your current faction. | `mf.help` |
+| `/mf invite <player>` | Invite a player to your faction. | `mf.help` |
+| `/mf kick <player>` | Kick a player from your faction. | `mf.help` |
+| `/mf disband` | Disband your faction. | `mf.help` |
+| `/mf transfer <player>` | Transfer faction ownership to another player. | `mf.help` |
+| `/mf power` | Check your current power level. | `mf.help` |
+| `/mf claim` | Claim the chunk you are standing in for your faction. | `mf.help` |
+| `/mf unclaim` | Unclaim the chunk you are standing in. | `mf.help` |
+| `/mf checkclaim` | Check which faction owns the chunk you are standing in. | `mf.help` |
+| `/mf config <view\|set> [option] [value]` | View or set config options. | `mf.help` |
+| `/mf force <subcommand>` | Force server events to occur (admin). | `mf.help` |

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -1,0 +1,14 @@
+# MiniFactions Configuration
+
+The configuration file is located at `plugins/MiniFactions/config.yml`.
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `version` | String | *(plugin version)* | Plugin version. Do not edit manually. |
+| `debugMode` | Boolean | `false` | Enables verbose debug logging to the console. |
+| `initialPower` | Double | `50.0` | Starting power level for new players. |
+| `territoryCostsPower` | Boolean | `true` | Whether claiming territory costs power. |
+| `minimumPowerCost` | Double | `1.0` | Minimum power cost to claim a chunk. |
+| `losePowerOnDeath` | Boolean | `true` | Whether players lose power when they die. |
+| `percentagePowerLostOnDeath` | Double | `0.10` | Fraction of power lost on death (e.g. `0.10` = 10%). |
+| `chunkRequirementFactor` | Double | `0.10` | Factor used to calculate how much power is required per claimed chunk. |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,66 @@
+# Contributing
+
+## Thank You
+
+Thank you for your interest in contributing to MiniFactions! This guide will help you get started.
+
+## Links
+
+- [Website](https://dansplugins.com)
+- [Discord](https://discord.gg/xXtuAQ2)
+
+## Requirements
+
+- A GitHub account
+- Git installed on your local machine
+- A Java IDE or text editor
+- A basic understanding of Java
+
+## Getting Started
+
+1. [Sign up for GitHub](https://github.com/signup) if you don't have an account.
+2. Fork the repository by clicking **Fork** at the top right of the repo page.
+3. Clone your fork: `git clone https://github.com/<your-username>/MiniFactions.git`
+4. Open the project in your IDE.
+5. Build the plugin: `mvn clean package`
+   If you encounter errors, please open an issue.
+
+## Identifying What to Work On
+
+### Issues
+
+Work items are tracked as [GitHub issues](https://github.com/Dans-Plugins/MiniFactions/issues).
+
+### Milestones
+
+Issues are grouped into [milestones](https://github.com/Dans-Plugins/MiniFactions/milestones) representing upcoming releases.
+
+## Making Changes
+
+1. Make sure an issue exists for the work. If not, create one.
+2. Switch to `main`: `git checkout main`
+3. Create a branch: `git checkout -b <branch-name>`
+4. Make your changes.
+5. Test your changes.
+6. Commit: `git commit -m "Description of changes"`
+7. Push: `git push origin <branch-name>`
+8. Open a pull request against `main`, link the related issue with `#<number>`.
+9. Address review feedback.
+
+## Testing
+
+Run the build with:
+
+Linux / macOS:
+
+    mvn clean package
+
+Windows:
+
+    mvn clean package
+
+For manual testing, place the built JAR from `target/` into a local Spigot server's `plugins` folder and restart the server.
+
+## Questions
+
+Ask in the [Discord server](https://discord.gg/xXtuAQ2).

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -30,7 +30,22 @@ Each player has a power level (default starting power: 50). Power:
 
 | Permission | Default | Description |
 |------------|---------|-------------|
-| `mf.help` | `true` | Access to all MiniFactions commands. |
+| `mf.help` | `true` | View the help menu. |
+| `mf.list` | `op` | List all factions. |
+| `mf.info` | `op` | View faction information. |
+| `mf.create` | `op` | Create a faction. |
+| `mf.join` | `op` | Join a faction. |
+| `mf.leave` | `op` | Leave a faction. |
+| `mf.invite` | `op` | Invite a player to your faction. |
+| `mf.kick` | `op` | Kick a player from your faction. |
+| `mf.disband` | `op` | Disband a faction. |
+| `mf.transfer` | `op` | Transfer faction ownership. |
+| `mf.power` | `op` | Check power level. |
+| `mf.claim` | `op` | Claim a chunk. |
+| `mf.unclaim` | `op` | Unclaim a chunk. |
+| `mf.checkclaim` | `op` | Check chunk ownership. |
+| `mf.config` | `op` | View or change config options. |
+| `mf.force` | `op` | Force admin actions. |
 
 ## Support
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1,0 +1,37 @@
+# MiniFactions User Guide
+
+## What is MiniFactions?
+
+MiniFactions is a lightweight Spigot plugin that adds a faction system to your Minecraft server. Players can form groups (factions), claim territory, invite allies, and compete for power.
+
+## Installation
+
+1. Download the latest `MiniFactions-<version>.jar` from the [Releases](https://github.com/Dans-Plugins/MiniFactions/releases) page.
+2. Place the JAR in your server's `plugins/` folder.
+3. Restart the server.
+4. The plugin generates `plugins/MiniFactions/config.yml` on first run.
+
+## Getting Started
+
+1. Create a faction: `/mf create <name>`
+2. Invite friends: `/mf invite <player>`
+3. Claim territory: stand in a chunk and run `/mf claim`
+4. Check who owns a chunk: `/mf checkclaim`
+
+## Power System
+
+Each player has a power level (default starting power: 50). Power:
+
+- Is spent when claiming chunks (`territoryCostsPower: true` by default).
+- Is lost on death (10% by default).
+- Determines how much territory your faction can hold.
+
+## Permissions
+
+| Permission | Default | Description |
+|------------|---------|-------------|
+| `mf.help` | `true` | Access to all MiniFactions commands. |
+
+## Support
+
+Ask questions in the [Discord server](https://discord.gg/xXtuAQ2) or open a [GitHub issue](https://github.com/Dans-Plugins/MiniFactions/issues).


### PR DESCRIPTION
Brings this repository into compliance with the [DPC conventions](https://github.com/Dans-Plugins/dpc-conventions).

### New files
- `CONTRIBUTING.md` — fork/branch/PR workflow, Maven build instructions
- `USER_GUIDE.md` — installation, power system overview, permissions table
- `COMMANDS.md` — full reference for all `/mf` subcommands
- `CONFIG.md` — all config options documented with types and defaults
- `CHANGELOG.md` — Keep a Changelog format seeded with 0.1-ALPHA
- `.github/copilot-instructions.md` — tech stack and contribution workflow
- `.github/workflows/build.yml` — CI on push/PR to `main`
- `.github/workflows/release.yml` — attaches JAR to GitHub Releases