### PR TITLE
Fix internal error claiming/checking a chunk left by a disbanded faction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+- `/mf claim`, `/mf force claim`, and `/mf checkclaim` no longer error out (or silently fail) on a territory chunk left claimed by a faction that has since been disbanded. Re-claiming a previously-existing, currently-unclaimed chunk now correctly registers it with the new owning faction so a later disband releases it again, and any already-stale claim is now automatically unclaimed with a message instead of crashing.
+
 ## [0.1-ALPHA]
 
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,11 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>3.2.4</version>
                 <executions>
@@ -84,6 +89,12 @@
             <groupId>com.github.Preponderous-Software</groupId>
             <artifactId>Ponder</artifactId>
             <version>1.1-SNAPSHOT-4-16-2022</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/dansplugins/minifactions/commands/config/force/ForceClaimCommand.java
+++ b/src/main/java/dansplugins/minifactions/commands/config/force/ForceClaimCommand.java
@@ -56,6 +56,7 @@ public class ForceClaimCommand extends AbstractMFCommand {
                 return false;
             }
             territoryChunk.setFactionUUID(faction.getId());
+            faction.claimChunk(territoryChunk);
         }
         else {
             TerritoryChunkFactory.getInstance().createTerritoryChunk(chunk, faction);

--- a/src/main/java/dansplugins/minifactions/commands/territory/CheckClaimCommand.java
+++ b/src/main/java/dansplugins/minifactions/commands/territory/CheckClaimCommand.java
@@ -53,8 +53,9 @@ public class CheckClaimCommand extends AbstractMFCommand {
         try {
             landholder = PersistentData.getInstance().getFaction(landholderUUID);
         } catch (Exception e) {
-            // this shouldn't happen
-            return false;
+            player.sendMessage("This territory was claimed by a faction that no longer exists. Unclaiming it.");
+            territoryChunk.setFactionUUID(null);
+            return true;
         }
 
         player.sendMessage("This territory is claimed by " + landholder.getName());

--- a/src/main/java/dansplugins/minifactions/commands/territory/ClaimCommand.java
+++ b/src/main/java/dansplugins/minifactions/commands/territory/ClaimCommand.java
@@ -63,6 +63,7 @@ public class ClaimCommand extends AbstractMFCommand {
                 }
             }
             territoryChunk.setFactionUUID(faction.getId());
+            faction.claimChunk(territoryChunk);
         }
         else {
             if (LocalConfigService.getInstance().getBoolean("territoryCostsPower")) { // TODO: fix duplication here
@@ -121,6 +122,9 @@ public class ClaimCommand extends AbstractMFCommand {
                 player.sendMessage("This territory is claimed by " + territoryChunk.getFaction().getName() + ".");
             } catch(TerritoryChunkNotClaimedException e) {
                 player.sendMessage("This territory is not claimed, but it was expected to be.");
+            } catch(FactionNotFoundException e) {
+                player.sendMessage("This territory was claimed by a faction that no longer exists. Unclaiming it.");
+                territoryChunk.setFactionUUID(null);
             }
             
         }

--- a/src/test/java/dansplugins/minifactions/objects/FactionImplTest.java
+++ b/src/test/java/dansplugins/minifactions/objects/FactionImplTest.java
@@ -1,0 +1,152 @@
+package dansplugins.minifactions.objects;
+
+import dansplugins.minifactions.api.definitions.core.Faction;
+import dansplugins.minifactions.api.definitions.core.TerritoryChunk;
+import dansplugins.minifactions.api.exceptions.FactionNotFoundException;
+import dansplugins.minifactions.data.PersistentData;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression coverage for the territory claim/disband contract behind
+ * https://github.com/Dans-Plugins/MiniFactions/issues/50: a territory chunk
+ * must only be considered claimed by a faction that actually tracks it, so
+ * that disbanding that faction always releases the chunk.
+ */
+class FactionImplTest {
+
+    @AfterEach
+    void clearPersistentData() {
+        PersistentData.getInstance().clearFactions();
+        PersistentData.getInstance().clearTerritoryChunks();
+    }
+
+    @Test
+    void claimChunk_registersChunkWithFaction() {
+        Faction faction = new FactionImpl("TestFaction", UUID.randomUUID());
+        TerritoryChunk chunk = new FakeTerritoryChunk();
+
+        boolean claimed = faction.claimChunk(chunk);
+
+        assertTrue(claimed);
+        assertTrue(faction.ownsChunk(chunk));
+        assertEquals(1, faction.getNumTerritoryChunks());
+    }
+
+    @Test
+    void unclaimAllChunks_onlyReleasesChunksRegisteredViaClaimChunk() {
+        Faction faction = new FactionImpl("TestFaction", UUID.randomUUID());
+        TerritoryChunk chunk = new FakeTerritoryChunk();
+        chunk.setFactionUUID(faction.getId());
+        PersistentData.getInstance().addTerritoryChunk(chunk);
+
+        // The chunk's factionUUID was set directly without going through
+        // faction.claimChunk(), reproducing the pre-fix ClaimCommand/
+        // ForceClaimCommand reclaim path. Because the faction never tracked
+        // the chunk, disbanding it cannot release the chunk.
+        faction.unclaimAllChunks();
+
+        assertTrue(chunk.isClaimed(), "chunk should still be stale-claimed when never registered via claimChunk()");
+    }
+
+    @Test
+    void unclaimAllChunks_releasesChunksThatWereProperlyClaimed() {
+        Faction faction = new FactionImpl("TestFaction", UUID.randomUUID());
+        TerritoryChunk chunk = new FakeTerritoryChunk();
+        chunk.setFactionUUID(faction.getId());
+        PersistentData.getInstance().addTerritoryChunk(chunk);
+        faction.claimChunk(chunk);
+
+        faction.unclaimAllChunks();
+
+        assertFalse(chunk.isClaimed());
+        assertNull(chunk.getFactionUUID());
+        assertFalse(faction.ownsChunk(chunk));
+    }
+
+    @Test
+    void reclaimingAPreviouslyClaimedChunk_mustSurviveANewDisband() {
+        // This mirrors the fixed ClaimCommand/ForceClaimCommand reclaim path:
+        // setFactionUUID() and claimChunk() must both be called so the new
+        // owning faction actually tracks the chunk.
+        Faction factionA = new FactionImpl("FactionA", UUID.randomUUID());
+        PersistentData.getInstance().addFaction(factionA);
+        TerritoryChunk chunk = new FakeTerritoryChunk();
+        chunk.setFactionUUID(factionA.getId());
+        PersistentData.getInstance().addTerritoryChunk(chunk);
+        factionA.claimChunk(chunk);
+
+        PersistentData.getInstance().removeFaction(factionA);
+        assertFalse(chunk.isClaimed(), "chunk should be released when its owning faction is disbanded");
+
+        Faction factionB = new FactionImpl("FactionB", UUID.randomUUID());
+        PersistentData.getInstance().addFaction(factionB);
+        chunk.setFactionUUID(factionB.getId());
+        factionB.claimChunk(chunk);
+
+        PersistentData.getInstance().removeFaction(factionB);
+
+        assertFalse(chunk.isClaimed(), "chunk claimed by a second faction must also be released on disband");
+        assertNull(chunk.getFactionUUID());
+    }
+
+    @Test
+    void getFaction_throwsForAnUnknownUUID() {
+        assertThrows(FactionNotFoundException.class, () -> PersistentData.getInstance().getFaction(UUID.randomUUID()));
+    }
+
+    /**
+     * Minimal {@link TerritoryChunk} test double. Avoids the default
+     * {@code getWorld()}/{@code getFaction()} methods so tests don't need a
+     * live Bukkit server.
+     */
+    private static class FakeTerritoryChunk implements TerritoryChunk {
+        private final UUID id = UUID.randomUUID();
+        private UUID factionUUID;
+
+        @Override
+        public UUID getFactionUUID() {
+            return factionUUID;
+        }
+
+        @Override
+        public void setFactionUUID(UUID factionUUID) {
+            this.factionUUID = factionUUID;
+        }
+
+        @Override
+        public int getX() {
+            return 0;
+        }
+
+        @Override
+        public int getZ() {
+            return 0;
+        }
+
+        @Override
+        public UUID getWorldId() {
+            return UUID.randomUUID();
+        }
+
+        @Override
+        public UUID getId() {
+            return id;
+        }
+
+        @Override
+        public Map<String, String> toJSON() {
+            return Collections.emptyMap();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- `ClaimCommand` and `ForceClaimCommand` re-claimed a previously-existing but currently-unclaimed chunk by setting `TerritoryChunk#setFactionUUID` directly, without calling `Faction#claimChunk`. The new owning faction never tracked the chunk, so disbanding that faction couldn't find it to release, leaving a stale `factionUUID` pointing at a faction that no longer exists.
- Looking up that stale faction UUID throws `FactionNotFoundException`, which was uncaught in `ClaimCommand#sendPlayerOwnerInfo` (surfacing to the player as Bukkit's generic "internal error") and silently swallowed with no feedback in `CheckClaimCommand`.
- Fix: register the chunk with the new faction via `claimChunk()` on reclaim (root cause), and treat an already-stale claim as auto-unclaimable with a clear message in both `ClaimCommand` and `CheckClaimCommand` (defensive fix for the crash symptom itself).
- Added JUnit 5 as the project's first test dependency (none existed previously) and a regression test (`FactionImplTest`) that locks in the claim/unclaim data-model contract the fix relies on — including a test that reproduces the exact stale-claim bug when a chunk's `factionUUID` is set without registering it via `claimChunk()`.

## Test plan
- [x] `mvn clean package` — compiles and packages the shaded jar successfully (this is also the CI anchor: `.github/workflows/build.yml` runs `mvn clean package`, which now also runs the new test suite).
- [x] `mvn test` — all 5 new tests pass.
- [x] Stash-and-run: reverting the `faction.claimChunk(territoryChunk)` line added to `ClaimCommand`/`ForceClaimCommand` isn't itself exercised by the new test (that logic lives in Bukkit `CommandSender`/`Player`/`Chunk`-dependent command classes, which would need heavy Bukkit mocking or a live server to drive directly — out of scope for a first unit test in this repo). Instead, `FactionImplTest#unclaimAllChunks_onlyReleasesChunksRegisteredViaClaimChunk` directly reproduces the underlying bug pattern (a chunk's `factionUUID` set without registering it via `claimChunk()`) and asserts the chunk incorrectly stays claimed after disband — i.e. it fails exactly the way production code failed pre-fix, and the sibling test `reclaimingAPreviouslyClaimedChunk_mustSurviveANewDisband` asserts the corrected pattern (used by the fixed `ClaimCommand`/`ForceClaimCommand`) releases the chunk correctly.
- [ ] Manual in-game validation (not run here — no live Spigot server in this sandbox): create faction A, `/mf claim` a chunk, `/mf disband`, create faction B, `/mf claim` the same chunk, `/mf disband` again, then `/mf claim`/`/mf checkclaim` that chunk once more from a third faction — confirm no "internal error" and a normal "Claimed."/ownership message. Also verify `/mf force claim <faction>` on a chunk that already belongs to a faction that no longer tracks it (simulating pre-existing stale data) prints the new "no longer exists" message instead of crashing.

Closes #50

<!-- gardener-tend-dispatch -->

---

_This PR description was drafted during a Gardener session ([Stephenson-Software/gardener](https://github.com/Stephenson-Software/gardener))._
