### PR TITLE
Document mf.default and mf.force.* permissions/commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - `/mf claim`, `/mf force claim`, and `/mf checkclaim` no longer error out (or silently fail) on a territory chunk left claimed by a faction that has since been disbanded. Re-claiming a previously-existing, currently-unclaimed chunk now correctly registers it with the new owning faction so a later disband releases it again, and any already-stale claim is now automatically unclaimed with a message instead of crashing.
 
+### Documentation
+- `COMMANDS.md` and `USER_GUIDE.md` now document the bare `/mf` command and the seven `/mf force <subcommand>` permissions (`mf.force.help`, `mf.force.join`, `mf.force.invite`, `mf.force.kick`, `mf.force.disband`, `mf.force.claim`, `mf.force.unclaim`), which existed in code but were previously undocumented.
+
 ## [0.1-ALPHA]
 
 ### Added

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -4,6 +4,7 @@ All commands use `/mf` or `/minifactions` or `/factions` or `/f` as the base.
 
 | Command | Description | Permission |
 |---------|-------------|------------|
+| `/mf` | Show plugin version and developer info. | `mf.default` |
 | `/mf help` | View a list of commands. | `mf.help` |
 | `/mf list` | View a list of all factions. | `mf.list` |
 | `/mf info` | View information about your faction. | `mf.info` |
@@ -20,3 +21,10 @@ All commands use `/mf` or `/minifactions` or `/factions` or `/f` as the base.
 | `/mf checkclaim` (alias: `/mf cc`) | Check which faction owns the chunk you are standing in. | `mf.checkclaim` |
 | `/mf config <show\|set> [option] [value]` | Show or set config options. | `mf.config` |
 | `/mf force <subcommand>` | Force server events to occur (admin). | `mf.force` |
+| `/mf force help` | View a list of force commands. | `mf.force.help` |
+| `/mf force join <ign> <faction>` | Force a player to join a faction. | `mf.force.join` |
+| `/mf force invite <ign> <faction>` | Forcefully invite a player to a faction. | `mf.force.invite` |
+| `/mf force kick <ign>` | Forcefully kick a player from their faction. | `mf.force.kick` |
+| `/mf force disband <faction>` | Forcefully disband a faction. | `mf.force.disband` |
+| `/mf force claim <faction>` | Forcefully claim territory for a faction. | `mf.force.claim` |
+| `/mf force unclaim <faction>` | Forcefully unclaim territory for a faction. | `mf.force.unclaim` |

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -31,6 +31,7 @@ Each player has a power level (default starting power: 50). Power:
 | Permission | Default | Description |
 |------------|---------|-------------|
 | `mf.help` | `true` | View the help menu. |
+| `mf.default` | n/a (not currently enforced) | Bare `/mf` command; shows plugin version and developer info. |
 | `mf.list` | `op` | List all factions. |
 | `mf.info` | `op` | View faction information. |
 | `mf.create` | `op` | Create a faction. |
@@ -46,6 +47,13 @@ Each player has a power level (default starting power: 50). Power:
 | `mf.checkclaim` | `op` | Check chunk ownership. |
 | `mf.config` | `op` | View or change config options. |
 | `mf.force` | `op` | Force admin actions. |
+| `mf.force.help` | `op` | View a list of force commands. |
+| `mf.force.join` | `op` | Force a player to join a faction. |
+| `mf.force.invite` | `op` | Forcefully invite a player to a faction. |
+| `mf.force.kick` | `op` | Forcefully kick a player from their faction. |
+| `mf.force.disband` | `op` | Forcefully disband a faction. |
+| `mf.force.claim` | `op` | Forcefully claim territory for a faction. |
+| `mf.force.unclaim` | `op` | Forcefully unclaim territory for a faction. |
 
 ## Support
 


### PR DESCRIPTION
<!-- gardener-tend-dispatch -->

## Summary

- The bare `/mf` command (`mf.default` permission, `DefaultCommand`) and the seven `/mf force <subcommand>` permissions (`mf.force.help`, `mf.force.join`, `mf.force.invite`, `mf.force.kick`, `mf.force.disband`, `mf.force.claim`, `mf.force.unclaim`) were found to exist in source without any corresponding row in `COMMANDS.md` or `USER_GUIDE.md`'s permissions table.
- `COMMANDS.md` and `USER_GUIDE.md` are updated with the missing rows, and `CHANGELOG.md`'s `[Unreleased]` section is given a new `Documentation` entry describing the change.
- No source files are touched; the diff is docs-only.

Two related but out-of-scope findings surfaced during triage were filed separately rather than folded into this PR, since fixing either would touch `plugin.yml` (a do-not-auto-merge path for this repo) or command-dispatch behavior (outside a documentation-only cycle's scope):
- #68 — most permission nodes are not registered in `plugin.yml` (only `mf.help` is), which is invisible to permission-management plugins even though runtime behavior is unaffected today.
- #69 — the bare `/mf` command's `mf.default` permission appears to bypass permission checking entirely, since `DefaultCommand` is invoked directly rather than through `commandService`.

The entire remaining backlog was empty at triage time (no open issues existed prior to this cycle; the only open item was a four-year-old stale draft PR, closed separately as unrelated to this cycle's scope).

## Test plan

- [x] `mvn compile` passes (docs-only change; no source touched).
- [x] Every added permission string cross-checked against its constructor call site in source (`grep -rn "mf\.\w" src/main/java/dansplugins/minifactions/commands/`).
- [ ] CI (`mvn clean package`) — pending, will confirm green before merge.

This PR description was drafted during a Gardener session (https://github.com/Stephenson-Software/gardener).