### PR TITLE
chore: release version 0.2.0-SNAPSHOT-8-8-2026

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [Unreleased]
+## [0.2.0-SNAPSHOT-8-8-2026] – 2026-08-08
+
+### Changed
+- MiniFactions is now developed AI-first. Day-to-day feature work, grooming, review and maintenance run through AI agents working directly against this repository, with the maintainers setting direction and approving what lands. The version bump marks that change in how the project is built — it is not a break in behaviour, configuration or stored data, and existing installations can upgrade in place. Released as `0.2.0-SNAPSHOT-8-8-2026`: the AI-first line has not yet been verified in live operation, and the dated snapshot designation stays until it has.
 
 ### Fixed
 - `/mf claim`, `/mf force claim`, and `/mf checkclaim` no longer error out (or silently fail) on a territory chunk left claimed by a faction that has since been disbanded. Re-claiming a previously-existing, currently-unclaimed chunk now correctly registers it with the new owning faction so a later disband releases it again, and any already-stale claim is now automatically unclaimed with a message instead of crashing.

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dansplugins</groupId>
     <artifactId>MiniFactions</artifactId>
-    <version>0.1-ALPHA</version>
+    <version>0.2.0-SNAPSHOT-8-8-2026</version>
     <packaging>jar</packaging>
 
     <name>MiniFactions</name>


### PR DESCRIPTION
## Summary

The version has been bumped from `0.1-ALPHA` to `0.2.0-SNAPSHOT-8-8-2026` in `pom.xml`.

The bump marks MiniFactions moving to an AI-first development approach: day-to-day feature work,
grooming, review and maintenance now run through AI agents working directly against this
repository, with the maintainers setting direction and approving what lands.

It is not a compatibility break. Behaviour, configuration and stored data are unchanged, and
existing installations can upgrade in place — the version marks a change in how the project is
built, not in what it does.

## Snapshot designation

The dated snapshot designation follows the precedent set by Medieval Factions'
`6.0.0-SNAPSHOT-7-25-2026`: the AI-first line has not yet been verified in live operation, and
the designation stays until it has.

## Notes

This is part of a garden-wide pass applying the same bump across every project tended by
Gardener. Only version metadata has been changed; no functional code was touched.

---
*Drafted by Claude on behalf of Daniel Stephenson.*
